### PR TITLE
test: Add Unit Test for ViewModels

### DIFF
--- a/POSSystem.Tests/ViewModels/AddProductViewModelTests.cs
+++ b/POSSystem.Tests/ViewModels/AddProductViewModelTests.cs
@@ -1,0 +1,351 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using POSSystem.Models;
+using POSSystem.Repositories;
+using POSSystem.Repository;
+using POSSystem.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace POSSystem.Tests.ViewModels
+{
+    [TestClass()]
+    public class AddProductViewModelTests
+    {
+        private Mock<IProductRepository> _productRepositoryMock;
+        private Mock<ICategoryRepository> _categoryRepositoryMock;
+        private Mock<IBrandRepository> _brandRepositoryMock;
+
+        private AddProductViewModel _addProductViewModel;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _productRepositoryMock = new Mock<IProductRepository>();
+            _categoryRepositoryMock = new Mock<ICategoryRepository>();
+            _brandRepositoryMock = new Mock<IBrandRepository>();
+
+            _addProductViewModel = new AddProductViewModel(_productRepositoryMock.Object, _categoryRepositoryMock.Object, _brandRepositoryMock.Object);
+        }
+
+        [TestMethod()]
+        public async Task LoadCategories_ShouldLoadCategoriesIntoViewModel()
+        {
+            // Arrange
+            var categories = new List<Category>
+            {
+                new Category { Id = 1, Name = "Category A" },
+                new Category { Id = 2, Name = "Category B" }
+            };
+
+            _categoryRepositoryMock.Setup(x => x.GetAllCategories()).ReturnsAsync(categories);
+
+            // Act
+            await _addProductViewModel.LoadCategories();
+
+            // Assert
+            Assert.AreEqual(categories, _addProductViewModel.Categories);
+        }
+
+        [TestMethod()]
+        public async Task LoadBrands_ShouldLoadBrandsIntoViewModel()
+        {
+            // Arrange
+            var brands = new List<Brand>
+            {
+                new Brand { Id = 1, Name = "Brand A" },
+                new Brand { Id = 2, Name = "Brand B" }
+            };
+
+            _brandRepositoryMock.Setup(x => x.GetAllBrands()).ReturnsAsync(brands);
+
+            // Act
+            await _addProductViewModel.LoadBrands();
+
+            // Assert
+            Assert.AreEqual(brands, _addProductViewModel.Brands);
+        }
+
+        [TestMethod()]
+        public void LoadSelectedValues_WhenProductIsNew_ShouldSetSelectedCategoryAndBrandToNull()
+        {
+            // Arrange
+            _addProductViewModel.Product = new Product();
+
+            // Act
+            _addProductViewModel.LoadSelectedValues();
+
+            // Assert
+            Assert.IsNull(_addProductViewModel.SelectedCategory);
+            Assert.IsNull(_addProductViewModel.SelectedBrand);
+        }
+
+        [TestMethod()]
+        public void LoadSelectedValues_WhenProductIsExisting_ShouldSetSelectedCategoryAndBrand()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Id = 1,
+                CategoryId = 1,
+                BrandId = 1
+            };
+
+            _addProductViewModel.Product = product;
+
+            _addProductViewModel.Categories = new List<Category>
+            {
+                new Category { Id = 1, Name = "Category A" },
+                new Category { Id = 2, Name = "Category B" }
+            };
+
+            _addProductViewModel.Brands = new List<Brand>
+            {
+                new Brand { Id = 1, Name = "Brand A" },
+                new Brand { Id = 2, Name = "Brand B" }
+            };
+
+            // Act
+            _addProductViewModel.LoadSelectedValues();
+
+            // Assert
+            Assert.AreEqual(_addProductViewModel.Categories[0], _addProductViewModel.SelectedCategory);
+            Assert.AreEqual(_addProductViewModel.Brands[0], _addProductViewModel.SelectedBrand);
+        }
+
+        [TestMethod()]
+        public async Task SaveProduct_WhenProductIsNew_ShouldAddProduct()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Name = "Product A",
+                Price = 5.5m,
+                Stock = 10,
+            };
+
+            _addProductViewModel.Product = product;
+            _addProductViewModel.SelectedCategory = new Category { Id = 1, Name = "Category A" };
+            _addProductViewModel.SelectedBrand = new Brand { Id = 1, Name = "Brand A" };
+
+            // Act
+            await _addProductViewModel.SaveProduct();
+
+            // Assert
+            _productRepositoryMock.Verify(x => x.AddProduct(product), Times.Once);
+        }
+
+        [TestMethod()]
+        public async Task SaveProduct_WhenProductIsExisting_ShouldUpdateProduct()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Id = 1,
+                Name = "Product A",
+                Price = 5.5m,
+                Stock = 10,
+            };
+
+            _addProductViewModel.Product = product;
+            _addProductViewModel.SelectedCategory = new Category { Id = 1, Name = "Category A" };
+            _addProductViewModel.SelectedBrand = new Brand { Id = 1, Name = "Brand A" };
+
+            // Act
+            await _addProductViewModel.SaveProduct();
+
+            // Assert
+            _productRepositoryMock.Verify(x => x.UpdateProduct(product), Times.Once);
+        }
+
+        [TestMethod()]
+        public async Task SaveProduct_ShouldSetProductCategoryIdAndBrandId()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Name = "Product A",
+                Price = 5.5m,
+                Stock = 10,
+            };
+
+            _addProductViewModel.Product = product;
+            _addProductViewModel.SelectedCategory = new Category { Id = 1, Name = "Category A" };
+            _addProductViewModel.SelectedBrand = new Brand { Id = 1, Name = "Brand A" };
+
+            // Act
+            await _addProductViewModel.SaveProduct();
+
+            // Assert
+            Assert.AreEqual(1, product.CategoryId);
+            Assert.AreEqual(1, product.BrandId);
+        }
+
+        [TestMethod()]
+        public async Task SaveProduct_WhenNameIsEmpty_ShouldThrowArgumentException()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Name = "",
+                Price = 5.5m,
+                Stock = 10,
+            };
+
+            _addProductViewModel.Product = product;
+
+            _addProductViewModel.SelectedBrand = new Brand { Id = 1, Name = "Brand A" };
+            _addProductViewModel.SelectedCategory = new Category { Id = 1, Name = "Category A" };
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _addProductViewModel.SaveProduct());
+            Assert.AreEqual("Product name is required and cannot only contain white spaces.", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task SaveProduct_WhenNameAllWhiteSpaces_ShouldThrowArgumentException()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Name = "   ",
+                Price = 5.5m,
+                Stock = 10,
+            };
+
+            _addProductViewModel.Product = product;
+
+            _addProductViewModel.SelectedBrand = new Brand { Id = 1, Name = "Brand A" };
+            _addProductViewModel.SelectedCategory = new Category { Id = 1, Name = "Category A" };
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _addProductViewModel.SaveProduct());
+            Assert.AreEqual("Product name is required and cannot only contain white spaces.", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task SaveProduct_WhenPriceIsEmpty_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Name = "Product A",
+                Price = null,
+                Stock = 10,
+            };
+
+            _addProductViewModel.Product = product;
+
+            _addProductViewModel.SelectedBrand = new Brand { Id = 1, Name = "Brand A" };
+            _addProductViewModel.SelectedCategory = new Category { Id = 1, Name = "Category A" };
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => _addProductViewModel.SaveProduct());
+            Assert.AreEqual("Value cannot be null. (Parameter 'Product price is required and must be a decimal.')", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task SaveProduct_WhenPriceIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Name = "Product A",
+                Price = -5.5m,
+                Stock = 10,
+            };
+
+            _addProductViewModel.Product = product;
+
+            _addProductViewModel.SelectedBrand = new Brand { Id = 1, Name = "Brand A" };
+            _addProductViewModel.SelectedCategory = new Category { Id = 1, Name = "Category A" };
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => _addProductViewModel.SaveProduct());
+            Assert.AreEqual("Specified argument was out of the range of valid values. (Parameter 'Product price must be greater than 0.')", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task SaveProduct_WhenStockIsEmpty_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Name = "Product A",
+                Price = 5.5m,
+                Stock = null,
+            };
+
+            _addProductViewModel.Product = product;
+
+            _addProductViewModel.SelectedBrand = new Brand { Id = 1, Name = "Brand A" };
+            _addProductViewModel.SelectedCategory = new Category { Id = 1, Name = "Category A" };
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => _addProductViewModel.SaveProduct());
+            Assert.AreEqual("Value cannot be null. (Parameter 'Product stock is required and must be an integer.')", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task SaveProduct_WhenStockIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Name = "Product A",
+                Price = 5.5m,
+                Stock = -10,
+            };
+
+            _addProductViewModel.Product = product;
+
+            _addProductViewModel.SelectedBrand = new Brand { Id = 1, Name = "Brand A" };
+            _addProductViewModel.SelectedCategory = new Category { Id = 1, Name = "Category A" };
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => _addProductViewModel.SaveProduct());
+            Assert.AreEqual("Specified argument was out of the range of valid values. (Parameter 'Product stock must be greater than 0.')", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task SaveProduct_WhenCategoryIsNull_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Name = "Product A",
+                Price = 5.5m,
+                Stock = 10,
+            };
+
+            _addProductViewModel.Product = product;
+
+            _addProductViewModel.SelectedBrand = new Brand { Id = 1, Name = "Brand A" };
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => _addProductViewModel.SaveProduct());
+            Assert.AreEqual("Value cannot be null. (Parameter 'Category is required.')", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task SaveProduct_WhenBrandIsNull_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            var product = new Product
+            {
+                Name = "Product A",
+                Price = 5.5m,
+                Stock = 10,
+            };
+
+            _addProductViewModel.Product = product;
+
+            _addProductViewModel.SelectedCategory = new Category { Id = 1, Name = "Category A" };
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => _addProductViewModel.SaveProduct());
+            Assert.AreEqual("Value cannot be null. (Parameter 'Brand is required.')", ex.Message);
+        }
+    }
+}

--- a/POSSystem.Tests/ViewModels/BrandViewModelTests.cs
+++ b/POSSystem.Tests/ViewModels/BrandViewModelTests.cs
@@ -1,0 +1,162 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using POSSystem.Repositories;
+using System.Threading.Tasks;
+using POSSystem.Models;
+using System.Collections.Generic;
+using POSSystem.ViewModels;
+using System;
+
+namespace POSSystem.Tests.ViewModels
+{
+    [TestClass()]
+    public class BrandViewModelTests
+    {
+        private Mock<IBrandRepository> _brandRepositoryMock;
+        private BrandViewModel _brandViewModel;
+        private List<Brand> _brands;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _brandRepositoryMock = new Mock<IBrandRepository>();
+            _brandViewModel = new BrandViewModel(_brandRepositoryMock.Object);
+
+            _brands = new List<Brand>()
+            {
+                new Brand { Id = 1, Name = "Brand A" },
+                new Brand { Id = 2, Name = "Brand B" }
+            };
+        }
+
+        [TestMethod()]
+        public async Task LoadBrands_ShouldLoadBrandsIntoViewModel()
+        {
+            // Arrange
+            _brandRepositoryMock.Setup(repo => repo.GetAllBrands()).ReturnsAsync(_brands);
+
+            // Act
+            await _brandViewModel.LoadBrands();
+
+            // Assert
+            Assert.AreEqual(2, _brandViewModel.Brands.Count);
+            Assert.AreEqual("Brand A", _brandViewModel.Brands[0].Name);
+            Assert.AreEqual(1, _brandViewModel.Brands[0].Index);
+        }
+
+        [TestMethod()]
+        public async Task AddBrand_ShouldAddBrandAndReloadBrands()
+        {
+            // Arrange
+            var newBrandName = "Brand C";
+
+            _brandRepositoryMock.Setup(repo => repo.AddBrand(It.IsAny<Brand>())).Returns(Task.CompletedTask);
+            _brandRepositoryMock.Setup(repo => repo.GetAllBrands()).ReturnsAsync(() =>
+            {
+                _brands.Add(new Brand { Name = newBrandName });
+                return _brands;
+            });
+
+            // Act
+            await _brandViewModel.AddBrand(newBrandName);
+
+            // Assert
+            _brandRepositoryMock.Verify(repo => repo.AddBrand(It.Is<Brand>(b => b.Name == newBrandName)), Times.Once);
+            Assert.AreEqual(3, _brandViewModel.Brands.Count);
+            Assert.AreEqual(newBrandName, _brandViewModel.Brands[2].Name);
+        }
+
+        [TestMethod()]
+        public async Task AddBrand_WhenNameIsEmpty_ShouldThrowArgumentException()
+        {
+            // Arrange
+            var newBrandName = string.Empty;
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _brandViewModel.AddBrand(newBrandName));
+            Assert.AreEqual("Brand name cannot be empty.", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task AddBrand_WhenNameWhiteAllSpaces_ShouldThrowArgumentException()
+        {
+            // Arrange
+            var newBrandName = "   ";
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _brandViewModel.AddBrand(newBrandName));
+            Assert.AreEqual("Brand name cannot be empty.", ex.Message);
+        }
+
+
+        [TestMethod()]
+        public async Task UpdateBrand_ShouldUpdateBrandAndReloadBrands()
+        {
+            // Arrange
+            int brandId = 1;
+            string updatedBrandName = "Brand A Updated";
+
+            _brandRepositoryMock.Setup(repo => repo.GetBrandById(brandId)).ReturnsAsync(new Brand { Id = brandId, Name = "Brand A" });
+            _brandRepositoryMock.Setup(repo => repo.UpdateBrand(It.IsAny<Brand>())).Returns(Task.CompletedTask);
+            _brandRepositoryMock.Setup(repo => repo.GetAllBrands()).ReturnsAsync(() =>
+            {
+                _brands[0].Name = updatedBrandName;
+                return _brands;
+            });
+
+            // Act
+            await _brandViewModel.UpdateBrand(brandId, updatedBrandName);
+
+            // Assert
+            _brandRepositoryMock.Verify(repo => repo.UpdateBrand(It.Is<Brand>(b => b.Id == brandId && b.Name == updatedBrandName)), Times.Once);
+            Assert.AreEqual(2, _brandViewModel.Brands.Count);
+            Assert.AreEqual(updatedBrandName, _brandViewModel.Brands[0].Name);
+        }
+
+        [TestMethod()]
+        public async Task UpdateBrand_WhenNameIsEmpty_ShouldThrowArgumentException()
+        {
+            // Arrange
+            int brandId = 1;
+            string updatedBrandName = string.Empty;
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _brandViewModel.UpdateBrand(brandId, updatedBrandName));
+            Assert.AreEqual("Brand name cannot be empty.", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task UpdateBrand_WhenNameAllWhiteSpaces_ShouldThrowArgumentException()
+        {
+            // Arrange
+            int brandId = 1;
+            string updatedBrandName = "   ";
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _brandViewModel.UpdateBrand(brandId, updatedBrandName));
+            Assert.AreEqual("Brand name cannot be empty.", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task DeleteBrand_ShouldDeleteBrandAndReloadBrands()
+        {
+            // Arrange
+            int brandId = 1;
+
+            _brandRepositoryMock.Setup(repo => repo.DeleteBrand(brandId)).Returns(Task.CompletedTask);
+            _brandRepositoryMock.Setup(repo => repo.GetAllBrands()).ReturnsAsync(() =>
+            {
+                _brands.RemoveAt(0);
+                return _brands;
+            });
+
+            // Act
+            await _brandViewModel.DeleteBrand(brandId);
+
+            // Assert
+            _brandRepositoryMock.Verify(repo => repo.DeleteBrand(brandId), Times.Once);
+            Assert.AreEqual(1, _brandViewModel.Brands.Count);
+            Assert.AreEqual("Brand B", _brandViewModel.Brands[0].Name);
+        }
+    }
+}

--- a/POSSystem.Tests/ViewModels/CategoryViewModelTests.cs
+++ b/POSSystem.Tests/ViewModels/CategoryViewModelTests.cs
@@ -1,0 +1,161 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using POSSystem.Repositories;
+using POSSystem.ViewModels;
+using System.Collections.Generic;
+using POSSystem.Models;
+using System.Threading.Tasks;
+using System;
+
+namespace POSSystem.Tests.ViewModels
+{
+    [TestClass()]
+    public class CategoryViewModelTests
+    {
+        private Mock<ICategoryRepository> _categoryRepositoryMock;
+        private CategoryViewModel _categoryViewModel;
+        private List<Category> _categories;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _categoryRepositoryMock = new Mock<ICategoryRepository>();
+            _categoryViewModel = new CategoryViewModel(_categoryRepositoryMock.Object);
+
+            _categories = new List<Category>
+            {
+                new Category { Id = 1, Name = "Category A" },
+                new Category { Id = 2, Name = "Category B" }
+            };
+        }
+
+        [TestMethod()]
+        public async Task LoadCategories_ShouldLoadCategoriesIntoViewModel()
+        {
+            // Arrange
+            _categoryRepositoryMock.Setup(repo => repo.GetAllCategories()).ReturnsAsync(_categories);
+
+            // Act
+            await _categoryViewModel.LoadCategories();
+
+            // Assert
+            Assert.AreEqual(2, _categoryViewModel.Categories.Count);
+            Assert.AreEqual("Category A", _categoryViewModel.Categories[0].Name);
+            Assert.AreEqual(1, _categoryViewModel.Categories[0].Index);
+        }
+
+        [TestMethod()]
+        public async Task AddCategory_ShouldAddCategoryAndReloadCategories()
+        {
+            // Arrange
+            var newCategoryName = "Category C";
+
+            _categoryRepositoryMock.Setup(repo => repo.AddCategory(It.IsAny<Category>())).Returns(Task.CompletedTask);
+            _categoryRepositoryMock.Setup(repo => repo.GetAllCategories()).ReturnsAsync(() =>
+            {
+                _categories.Add(new Category { Name = newCategoryName });
+                return _categories;
+            });
+
+            // Act
+            await _categoryViewModel.AddCategory(newCategoryName);
+
+            // Assert
+            _categoryRepositoryMock.Verify(repo => repo.AddCategory(It.Is<Category>(c => c.Name == newCategoryName)), Times.Once);
+            Assert.AreEqual(3, _categoryViewModel.Categories.Count);
+            Assert.AreEqual(newCategoryName, _categoryViewModel.Categories[2].Name);
+        }
+
+        [TestMethod()]
+        public async Task AddCategory_WhenNameIsEmpty_ShouldThrowArgumentException()
+        {
+            // Arrange
+            var newCategoryName = "";
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _categoryViewModel.AddCategory(newCategoryName));
+            Assert.AreEqual("Category name cannot be empty.", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task AddCategory_WhenNameAllWhiteSpaces_ShouldThrowArgumentException()
+        {
+            // Arrange
+            var categoryId = 1;
+            var updatedCategoryName = "   ";
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _categoryViewModel.UpdateCategory(categoryId, updatedCategoryName));
+            Assert.AreEqual("Category name cannot be empty.", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task UpdateCategory_ShouldUpdateCategoryAndReloadCategories()
+        {
+            // Arrange
+            var categoryId = 1;
+            var updatedCategoryName = "Category A Updated";
+
+            _categoryRepositoryMock.Setup(repo => repo.GetCategoryById(categoryId)).ReturnsAsync(new Category { Id = categoryId, Name = "Category A" });
+            _categoryRepositoryMock.Setup(repo => repo.UpdateCategory(It.IsAny<Category>())).Returns(Task.CompletedTask);
+            _categoryRepositoryMock.Setup(repo => repo.GetAllCategories()).ReturnsAsync(() =>
+            {
+                _categories[0].Name = updatedCategoryName;
+                return _categories;
+            });
+
+            // Act
+            await _categoryViewModel.UpdateCategory(categoryId, updatedCategoryName);
+
+            // Assert
+            _categoryRepositoryMock.Verify(repo => repo.UpdateCategory(It.Is<Category>(c => c.Id == categoryId && c.Name == updatedCategoryName)), Times.Once);
+            Assert.AreEqual(2, _categoryViewModel.Categories.Count);
+            Assert.AreEqual(updatedCategoryName, _categoryViewModel.Categories[0].Name);
+        }
+
+        [TestMethod()]
+        public async Task UpdateCategory_WhenNameIsEmpty_ShouldThrowArgumentException()
+        {
+            // Arrange
+            var categoryId = 1;
+            var updatedCategoryName = "";
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _categoryViewModel.UpdateCategory(categoryId, updatedCategoryName));
+            Assert.AreEqual("Category name cannot be empty.", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task UpdateCategory_WhenNameAllWhiteSpaces_ShouldThrowArgumentException()
+        {
+            // Arrange
+            var categoryId = 1;
+            var updatedCategoryName = "   ";
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _categoryViewModel.UpdateCategory(categoryId, updatedCategoryName));
+            Assert.AreEqual("Category name cannot be empty.", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task DeleteCategory_ShouldDeleteCategoryAndReloadCategories()
+        {
+            var categoryId = 1;
+
+            _categoryRepositoryMock.Setup(repo => repo.DeleteCategory(categoryId)).Returns(Task.CompletedTask);
+            _categoryRepositoryMock.Setup(repo => repo.GetAllCategories()).ReturnsAsync(() =>
+            {
+                _categories.RemoveAt(0);
+                return _categories;
+            });
+
+            // Act
+            await _categoryViewModel.DeleteCategory(categoryId);
+
+            // Assert
+            _categoryRepositoryMock.Verify(repo => repo.DeleteCategory(categoryId), Times.Once);
+            Assert.AreEqual(1, _categoryViewModel.Categories.Count);
+            Assert.AreEqual("Category B", _categoryViewModel.Categories[0].Name);
+        }
+    }
+}

--- a/POSSystem.Tests/ViewModels/LoginViewModelTests.cs
+++ b/POSSystem.Tests/ViewModels/LoginViewModelTests.cs
@@ -1,0 +1,219 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using POSSystem.Repository;
+using POSSystem.Services;
+using POSSystem.ViewModels;
+using POSSystem.Models;
+using System.Threading.Tasks;
+
+namespace POSSystem.Tests.ViewModels
+{
+    [TestClass()]
+    public class LoginViewModelTests
+    {
+        private Mock<IEmployeeRepository> _employeeRepositoryMock;
+        private Mock<IGoogleOAuthService> _googleOAuthServiceMock;
+        private Mock<ISettingsService> _settingsServiceMock;
+        private Mock<IEncryptionService> _encryptionServiceMock;
+
+        private LoginViewModel _loginViewModel;
+
+        private readonly int _id = 1;
+        private readonly string _name = "Admin";
+        private readonly string _email = "admin@enkay.live";
+        private readonly string _password = "12345678Aa";
+        private readonly string _encryptedPassword = "$2a$10$P13f37S6P4kN3JaY8i/a/O700M4NCqRv4LtOiLZ3IIozaj3ozqFnG";
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _employeeRepositoryMock = new Mock<IEmployeeRepository>();
+            _googleOAuthServiceMock = new Mock<IGoogleOAuthService>();
+            _settingsServiceMock = new Mock<ISettingsService>();
+            _encryptionServiceMock = new Mock<IEncryptionService>();
+
+            _loginViewModel = new LoginViewModel(_employeeRepositoryMock.Object, _googleOAuthServiceMock.Object, _settingsServiceMock.Object, _encryptionServiceMock.Object);
+        }
+
+        [TestMethod()]
+        public void Login_WhenEmailAndPasswordAreCorrect_ShouldReturnName()
+        {
+            // Arrange
+            _loginViewModel.Email = _email;
+            _loginViewModel.Password = _password;
+
+            _employeeRepositoryMock.Setup(repo => repo.GetEmployeeByEmail(_email)).ReturnsAsync(new Employee
+            {
+                Id = _id,
+                Name = _name,
+                Email = _email,
+                Password = _encryptedPassword
+            });
+
+            // Act
+            string name = _loginViewModel.Login().Result;
+
+            // Assert
+            Assert.AreEqual(_name, name);
+        }
+
+        [TestMethod()]
+        public void Login_WhenEmailIsIncorrect_ShouldReturnNull()
+        {
+            // Arrange
+            _loginViewModel.Email = _email;
+            _loginViewModel.Password = _password;
+
+            _employeeRepositoryMock.Setup(repo => repo.GetEmployeeByEmail(_email)).ReturnsAsync((Employee)null);
+
+            // Act
+            string name = _loginViewModel.Login().Result;
+
+            // Assert
+            Assert.IsNull(name);
+        }
+
+        [TestMethod()]
+        public void Login_WhenPasswordIsIncorrect_ShouldReturnsNull()
+        {
+            // Arrange
+            string wrongPassword = "12345678Bb";
+
+            _loginViewModel.Email = _email;
+            _loginViewModel.Password = wrongPassword;
+
+            _employeeRepositoryMock.Setup(repo => repo.GetEmployeeByEmail(_email)).ReturnsAsync(new Employee
+            {
+                Id = _id,
+                Name = _name,
+                Email = _email,
+                Password = _encryptedPassword
+            });
+
+            // Act
+            string name = _loginViewModel.Login().Result;
+
+            // Assert
+            Assert.IsNull(name);
+        }
+
+        [TestMethod()]
+        public void Login_WhenRememberMeIsChecked_ShouldSaveCredentials()
+        {
+            // Arrange
+            _loginViewModel.Email = _email;
+            _loginViewModel.Password = _password;
+
+            _employeeRepositoryMock.Setup(repo => repo.GetEmployeeByEmail(_email)).ReturnsAsync(new Employee
+            {
+                Id = _id,
+                Name = _name,
+                Email = _email,
+                Password = _encryptedPassword,
+            });
+
+            _loginViewModel.IsRememberMeChecked = true;
+
+            // Act
+            string name = _loginViewModel.Login().Result;
+
+            // Assert
+            _settingsServiceMock.Verify(service => service.Save("Email", _email), Times.Once);
+            _settingsServiceMock.Verify(service => service.Save("Password", It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod()]
+        public void Login_WhenRememberMeIsNotChecked_ShouldClearSavedCredentials()
+        {
+            // Arrange
+            _loginViewModel.Email = _email;
+            _loginViewModel.Password = _password;
+
+            _employeeRepositoryMock.Setup(repo => repo.GetEmployeeByEmail(_email)).ReturnsAsync(new Employee
+            {
+                Id = _id,
+                Name = _name,
+                Email = _email,
+                Password = _encryptedPassword,
+            });
+
+            _loginViewModel.IsRememberMeChecked = false;
+
+            // Act
+            string name = _loginViewModel.Login().Result;
+
+            // Assert
+            _settingsServiceMock.Verify(service => service.Remove("Email"), Times.Once);
+            _settingsServiceMock.Verify(service => service.Remove("Password"), Times.Once);
+        }
+
+        [TestMethod()]
+        public async Task SaveCredentialsAsync_ShouldSaveCredentials()
+        {
+            // Arrange
+            _loginViewModel.Email = _email;
+            _loginViewModel.Password = _password;
+
+            // Act
+            await _loginViewModel.SaveCredentialsAsync();
+
+            // Assert
+            _settingsServiceMock.Verify(service => service.Save("Email", _email), Times.Once);
+            _settingsServiceMock.Verify(service => service.Save("Password", It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod()]
+        public async Task LoadSavedCredentials_ShouldLoadsSavedCredentials()
+        {
+            // Arrange
+            _settingsServiceMock.Setup(service => service.Load("Email")).Returns(_email);
+            _settingsServiceMock.Setup(service => service.Load("Password")).Returns(_encryptedPassword);
+
+            _encryptionServiceMock.Setup(service => service.DecryptAsync(_encryptedPassword)).ReturnsAsync(_password);
+
+            // Act
+            await _loginViewModel.LoadSavedCredentials();
+
+            // Assert
+            Assert.AreEqual(_email, _loginViewModel.Email);
+            Assert.AreEqual(_password, _loginViewModel.Password);
+            Assert.IsTrue(_loginViewModel.IsRememberMeChecked);
+        }
+
+        [TestMethod()]
+        public void ClearSavedCredentials_ShouldRemovesSavedCredentials()
+        {
+            // Arrange
+            _settingsServiceMock.Setup(service => service.Load("Email")).Returns(_email);
+            _settingsServiceMock.Setup(service => service.Load("Password")).Returns(_encryptedPassword);
+
+            // Act
+            _loginViewModel.ClearSavedCredentials();
+
+            // Assert
+            _settingsServiceMock.Verify(service => service.Remove("Email"), Times.Once);
+            _settingsServiceMock.Verify(service => service.Remove("Password"), Times.Once);
+        }
+
+        [TestMethod()]
+        public void AuthenticateWithGoogle_WhenTokenIsValid_ShouldReturnName()
+        {
+            // Arrange
+            Employee employee = new Employee
+            {
+                Id = 2,
+                Name = "eNKay",
+                Email = "enkay@enkay.live",
+            };
+
+            _googleOAuthServiceMock.Setup(service => service.AuthenticateAsync()).ReturnsAsync(employee);
+
+            // Act
+            string name = _loginViewModel.AuthenticateWithGoogle().Result;
+
+            // Assert
+            _employeeRepositoryMock.Verify(repo => repo.SaveEmployeeFromGoogle(employee), Times.Once);
+            Assert.AreEqual("eNKay", name);
+        }
+    }
+}

--- a/POSSystem.Tests/ViewModels/ProductViewModelTests.cs
+++ b/POSSystem.Tests/ViewModels/ProductViewModelTests.cs
@@ -1,0 +1,330 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using POSSystem.ViewModels;
+using POSSystem.Models;
+using POSSystem.Repository;
+using System.Collections.Generic;
+using POSSystem.Repositories;
+using System.Threading.Tasks;
+using POSSystem.Services;
+using System;
+namespace POSSystem.Tests.ViewModels
+{
+    [TestClass()]
+    public class ProductViewModelTests
+    {
+        private Mock<IProductRepository> _productRepositoryMock;
+        private Mock<ICategoryRepository> _categoryRepositoryMock;
+        private Mock<IBrandRepository> _brandRepositoryMock;
+        private Mock<IStripeService> _stripeServiceMock;
+        private Mock<IUriLauncher> _uriLauncherMock;
+
+        private ProductViewModel _productViewModel;
+
+        private List<Product> _products;
+        private Brand _brand;
+        private Category _category;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _productRepositoryMock = new Mock<IProductRepository>();
+            _brandRepositoryMock = new Mock<IBrandRepository>();
+            _categoryRepositoryMock = new Mock<ICategoryRepository>();
+            _stripeServiceMock = new Mock<IStripeService>();
+            _uriLauncherMock = new Mock<IUriLauncher>();
+
+            _productViewModel = new ProductViewModel(_productRepositoryMock.Object, _categoryRepositoryMock.Object, _brandRepositoryMock.Object, _stripeServiceMock.Object, _uriLauncherMock.Object);
+
+            _products = new List<Product>
+            {
+                new Product { Id = 1, Name = "Product A", Price= 5.5m , Stock =10,  CategoryId = 1, BrandId = 1 },
+                new Product { Id = 2, Name = "Product B", Price = 10.10m , Stock=20, CategoryId = 1, BrandId = 1 }
+            };
+            _brand = new Brand() { Id = 1, Name = "Brand A" };
+            _category = new Category() { Id = 1, Name = "Category A" };
+        }
+
+        [TestMethod()]
+        public async Task LoadProducts_ShouldLoadProductsIntoViewModel()
+        {
+            // Arrange
+            _productRepositoryMock.Setup(repo => repo.GetAllProducts()).ReturnsAsync(_products);
+            _categoryRepositoryMock.Setup(repo => repo.GetCategoryById(It.IsAny<int>())).ReturnsAsync(_category);
+            _brandRepositoryMock.Setup(repo => repo.GetBrandById(It.IsAny<int>())).ReturnsAsync(_brand);
+
+
+            // Act
+            await _productViewModel.LoadProducts();
+
+            // Assert
+            Assert.AreEqual(2, _productViewModel.Products.Count);
+            Assert.AreEqual("Product A", _productViewModel.Products[0].Name);
+            Assert.AreEqual("Category A", _productViewModel.Products[0].CategoryName);
+            Assert.AreEqual("Brand A", _productViewModel.Products[0].BrandName);
+            Assert.AreEqual(1, _productViewModel.Products[0].Index);
+        }
+
+        [TestMethod()]
+        public async Task LoadCategories_ShouldLoadCategoriesIntoViewModel()
+        {
+            // Arrange
+            var categories = new List<Category>
+            {
+                new Category { Name = "Category A" },
+                new Category { Name = "Category B" }
+            };
+            _categoryRepositoryMock.Setup(repo => repo.GetAllCategories()).ReturnsAsync(categories);
+
+            // Act
+            await _productViewModel.LoadCategories();
+
+            // Assert
+            Assert.AreEqual(3, _productViewModel.Categories.Count);
+            Assert.AreEqual("All", _productViewModel.Categories[0].Name);
+            Assert.AreEqual("Category A", _productViewModel.Categories[1].Name);
+        }
+
+        [TestMethod()]
+        public async Task AddProduct_ShouldAddProductAndReloadProducts()
+        {
+            // Arrange
+            string name = "Product C";
+            decimal price = 15.15m;
+            int stock = 30;
+            int categoryId = 1;
+            int brandId = 1;
+
+            _productRepositoryMock.Setup(repo => repo.AddProduct(It.IsAny<Product>())).Returns(Task.CompletedTask);
+            _productRepositoryMock.Setup(repo => repo.GetAllProducts()).ReturnsAsync(() =>
+            {
+                var newProduct = new Product
+                {
+                    Name = name,
+                    Price = price,
+                    Stock = stock,
+                    CategoryId = categoryId,
+                    BrandId = brandId
+                };
+                _products.Add(newProduct);
+                return _products;
+            });
+            _categoryRepositoryMock.Setup(repo => repo.GetCategoryById(It.IsAny<int>())).ReturnsAsync(_category);
+            _brandRepositoryMock.Setup(repo => repo.GetBrandById(It.IsAny<int>())).ReturnsAsync(_brand);
+
+            // Act
+            await _productViewModel.AddProduct(name, price, stock, categoryId, brandId);
+
+            // Assert
+            _productRepositoryMock.Verify(repo => repo.AddProduct(It.Is<Product>(p => p.Name == name && p.Price == price && p.Stock == stock && p.CategoryId == categoryId && p.BrandId == brandId)), Times.Once);
+            Assert.AreEqual(3, _productViewModel.Products.Count);
+            Assert.AreEqual(name, _productViewModel.Products[2].Name);
+            Assert.AreEqual(price, _productViewModel.Products[2].Price);
+            Assert.AreEqual(stock, _productViewModel.Products[2].Stock);
+            Assert.AreEqual("Category A", _productViewModel.Products[2].CategoryName);
+            Assert.AreEqual("Brand A", _productViewModel.Products[2].BrandName);
+        }
+
+        [TestMethod()]
+        public async Task UpdateProduct_ShouldUpdateProductAndReloadProducts()
+        {
+            // Arrange
+            int id = 1;
+            string newName = "Product A Updated";
+            decimal newPrice = 6.6m;
+            int newStock = 12;
+            int newCategoryId = 2;
+            int newBrandId = 2;
+
+            _productRepositoryMock.Setup(repo => repo.GetProductById(id)).ReturnsAsync(_products[0]);
+            _productRepositoryMock.Setup(repo => repo.UpdateProduct(It.IsAny<Product>())).Returns(Task.CompletedTask);
+            _productRepositoryMock.Setup(repo => repo.GetAllProducts()).ReturnsAsync(() =>
+            {
+                _products[0].Name = newName;
+                _products[0].Price = newPrice;
+                _products[0].Stock = newStock;
+                _products[0].CategoryId = newCategoryId;
+                _products[0].BrandId = newBrandId;
+                return _products;
+            });
+            _categoryRepositoryMock.Setup(repo => repo.GetCategoryById(It.IsAny<int>())).ReturnsAsync(new Category { Id = newCategoryId, Name = "Category B" });
+            _brandRepositoryMock.Setup(repo => repo.GetBrandById(It.IsAny<int>())).ReturnsAsync(new Brand { Id = newBrandId, Name = "Brand B" });
+
+            // Act
+            await _productViewModel.UpdateProduct(id, newName, newPrice, newStock, newCategoryId, newBrandId);
+
+            // Assert
+            _productRepositoryMock.Verify(repo => repo.UpdateProduct(It.Is<Product>(p => p.Id == id && p.Name == newName && p.Price == newPrice && p.Stock == newStock && p.CategoryId == newCategoryId && p.BrandId == newBrandId)), Times.Once);
+            Assert.AreEqual(2, _productViewModel.Products.Count);
+            Assert.AreEqual(newName, _productViewModel.Products[0].Name);
+            Assert.AreEqual(newPrice, _productViewModel.Products[0].Price);
+            Assert.AreEqual(newStock, _productViewModel.Products[0].Stock);
+            Assert.AreEqual("Category B", _productViewModel.Products[0].CategoryName);
+            Assert.AreEqual("Brand B", _productViewModel.Products[0].BrandName);
+        }
+
+        [TestMethod()]
+        public async Task DeleteProduct_ShouldDeleteProductAndReloadProducts()
+        {
+            // Arrange
+            int id = 1;
+
+            _productRepositoryMock.Setup(repo => repo.DeleteProduct(id)).Returns(Task.CompletedTask);
+            _productRepositoryMock.Setup(repo => repo.GetAllProducts()).ReturnsAsync(() =>
+            {
+                _products.RemoveAt(0);
+                return _products;
+            });
+            _categoryRepositoryMock.Setup(repo => repo.GetCategoryById(It.IsAny<int>())).ReturnsAsync(_category);
+            _brandRepositoryMock.Setup(repo => repo.GetBrandById(It.IsAny<int>())).ReturnsAsync(_brand);
+
+            // Act
+            await _productViewModel.DeleteProduct(id);
+
+            // Assert
+            _productRepositoryMock.Verify(repo => repo.DeleteProduct(id), Times.Once);
+            Assert.AreEqual(1, _productViewModel.Products.Count);
+            Assert.AreEqual("Product B", _productViewModel.Products[0].Name);
+        }
+
+        [TestMethod()]
+        public async Task FilterProducts_ByNameProduct_ShouldFilterProductsByName()
+        {
+            var filterText = "A";
+
+            _productRepositoryMock.Setup(repo => repo.GetAllProducts()).ReturnsAsync(_products);
+            _categoryRepositoryMock.Setup(repo => repo.GetCategoryById(It.IsAny<int>())).ReturnsAsync(_category);
+            _brandRepositoryMock.Setup(repo => repo.GetBrandById(It.IsAny<int>())).ReturnsAsync(_brand);
+
+            _productViewModel.FilterText = filterText;
+
+            // Act
+            await _productViewModel.FilterProducts();
+
+            // Assert
+            Assert.AreEqual(1, _productViewModel.Products.Count);
+            Assert.AreEqual("Product A", _productViewModel.Products[0].Name);
+        }
+
+        [TestMethod()]
+        public async Task FilterProducts_ByCategory_ShouldFilterProductsByCategory()
+        {
+            var selectedCategory = new Category { Id = 2, Name = "Category B" };
+
+
+            _productRepositoryMock.Setup(repo => repo.GetAllProducts()).ReturnsAsync(_products);
+            _categoryRepositoryMock.Setup(repo => repo.GetCategoryById(It.IsAny<int>())).ReturnsAsync(_category);
+            _brandRepositoryMock.Setup(repo => repo.GetBrandById(It.IsAny<int>())).ReturnsAsync(_brand);
+
+            _productViewModel.SelectedCategory = selectedCategory;
+
+            // Act
+            await _productViewModel.FilterProducts();
+
+            // Assert
+            Assert.AreEqual(0, _productViewModel.Products.Count);
+        }
+
+        public async Task FilterProducts_ByMaxPrice_ShouldFilterProductsByMaxPrice()
+        {
+            var maxPrice = 6.0m;
+
+            _productRepositoryMock.Setup(repo => repo.GetAllProducts()).ReturnsAsync(_products);
+            _categoryRepositoryMock.Setup(repo => repo.GetCategoryById(It.IsAny<int>())).ReturnsAsync(_category);
+            _brandRepositoryMock.Setup(repo => repo.GetBrandById(It.IsAny<int>())).ReturnsAsync(_brand);
+
+            _productViewModel.MaxPrice = maxPrice;
+
+            // Act
+            await _productViewModel.FilterProducts();
+
+            // Assert
+            Assert.AreEqual(1, _productViewModel.Products.Count);
+            Assert.AreEqual("Product A", _productViewModel.Products[0].Name);
+        }
+
+        [TestMethod()]
+        public async Task FilterProducts_ByProductNameCategoryAndMaxPrice_ShouldFilterProducts()
+        {
+            var filterText = "A";
+            var maxPrice = 6.0m;
+            var selectedCategory = new Category { Id = 1, Name = "Category A" };
+
+            _products.Add(new Product { Id = 3, Name = "Product A New", Price = 7.0m, Stock = 14, CategoryId = 1, BrandId = 1 });
+            _products.Add(new Product { Id = 4, Name = "Product A Super New", Price = 6.0m, Stock = 12, CategoryId = 2, BrandId = 2 });
+
+            _productRepositoryMock.Setup(repo => repo.GetAllProducts()).ReturnsAsync(_products);
+            _categoryRepositoryMock.Setup(repo => repo.GetCategoryById(It.IsAny<int>())).ReturnsAsync(_category);
+            _brandRepositoryMock.Setup(repo => repo.GetBrandById(It.IsAny<int>())).ReturnsAsync(_brand);
+
+            _productViewModel.FilterText = filterText;
+            _productViewModel.SelectedCategory = selectedCategory;
+            _productViewModel.MaxPrice = maxPrice;
+
+            // Act
+            await _productViewModel.FilterProducts();
+
+            // Assert
+            Assert.AreEqual(1, _productViewModel.Products.Count);
+            Assert.AreEqual("Product A", _productViewModel.Products[0].Name);
+        }
+
+        [TestMethod()]
+        public void SortByPrice_ShouldSortProductsByPriceDescending()
+        {
+            _productViewModel.Products = _products;
+
+            // Act
+            _productViewModel.SortByPrice();
+
+            // Assert
+            Assert.AreEqual("Product B", _productViewModel.Products[0].Name);
+            Assert.AreEqual("Product A", _productViewModel.Products[1].Name);
+        }
+
+        [TestMethod()]
+        public void SortByPrice_ShouldSortProductsByPriceAscending()
+        {
+            _products.Reverse();
+            _productViewModel.Products = _products;
+
+            // Act
+            _productViewModel.SortByPrice();
+
+            // Assert
+            Assert.AreEqual("Product A", _productViewModel.Products[0].Name);
+            Assert.AreEqual("Product B", _productViewModel.Products[1].Name);
+        }
+
+        [TestMethod()]
+        public async Task PayProduct_WhenCalled_ShouldCallStripeService()
+        {
+            // Arrange
+            var product = new Product { Id = 1, Name = "Product A", Price = 5.5m, Stock = 10, CategoryId = 1, BrandId = 1 };
+            var quantity = 2;
+            var checkoutSessionUrl = "https://example.com/checkout";
+
+            _stripeServiceMock.Setup(service => service.CreateCheckoutSession(product, quantity)).ReturnsAsync(checkoutSessionUrl);
+
+            // Act
+            await _productViewModel.PayProduct(product, quantity);
+
+            // Assert
+            _stripeServiceMock.Verify(service => service.CreateCheckoutSession(product, quantity), Times.Once);
+            _uriLauncherMock.Verify(launcher => launcher.LaunchUriAsync(It.Is<Uri>(u => u.ToString() == checkoutSessionUrl)), Times.Once);
+        }
+
+        [TestMethod()]
+        public async Task PayProduct_WhenStripeServiceThrowsException_ShouldThrowException()
+        {
+            // Arrange
+            var product = new Models.Product { Id = 1, Name = "Product A", Price = 5.5m, Stock = 10, CategoryId = 1, BrandId = 1 };
+            var quantity = 2;
+
+            _stripeServiceMock.Setup(service => service.CreateCheckoutSession(product, quantity)).ThrowsAsync(new Stripe.StripeException());
+
+            // Act & Assert
+            await Assert.ThrowsExceptionAsync<Stripe.StripeException>(() => _productViewModel.PayProduct(product, quantity));
+        }
+    }
+}

--- a/POSSystem.Tests/ViewModels/RegisterViewModelTests.cs
+++ b/POSSystem.Tests/ViewModels/RegisterViewModelTests.cs
@@ -1,0 +1,238 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using POSSystem.Models;
+using POSSystem.Repository;
+using POSSystem.ViewModels;
+using System;
+using System.Threading.Tasks;
+
+
+namespace POSSystem.Tests.ViewModels
+{
+    [TestClass()]
+    public class RegisterViewModelTests
+    {
+        private Mock<IEmployeeRepository> _employeeRepositoryMock;
+
+        private RegisterViewModel _registerViewModel;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _employeeRepositoryMock = new Mock<IEmployeeRepository>();
+
+            _registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+        }
+
+        [TestMethod()]
+        public void IsStrongPassword_WhenPasswordContainsUpperCaseLowerCaseAndNumber_ShouldReturnsTrue()
+        {
+            // Arrange
+            var registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+            string password = "12345678Aa";
+
+            // Act
+            var result = RegisterViewModel.IsStrongPassword(password);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod()]
+        public void IsStrongPassword_WhenPasswordLengthLessThan8_ShouldReturnsFalse()
+        {
+            // Arrange
+            var registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+            string password = "1234567";
+
+            // Act
+            var result = RegisterViewModel.IsStrongPassword(password);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod()]
+        public void IsStrongPassword_WhenPasswordDoesNotContainUpperCase_ShouldReturnsFalse()
+        {
+            // Arrange
+            var registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+            string password = "12345678A";
+
+            // Act
+            var result = RegisterViewModel.IsStrongPassword(password);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod()]
+        public void IsStrongPassword_WhenPasswordDoesNotContainLowerCase_ShouldReturnsFalse()
+        {
+            // Arrange
+            var registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+            string password = "12345678A";
+
+            // Act
+            var result = RegisterViewModel.IsStrongPassword(password);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod()]
+        public void IsStrongPassword_WhenPasswordDoesNotContainNumber_ShouldReturnsFalse()
+        {
+            // Arrange
+            var registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+            string password = "ABCDEFGH";
+
+            // Act
+            var result = RegisterViewModel.IsStrongPassword(password);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod()]
+        public void IsEmail_WhenEmailIsValid_ShouldReturnsTrue()
+        {
+            // Arrange
+            var registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+            string email = "admin@enkay.live";
+
+            // Act
+            var result = RegisterViewModel.IsEmail(email);
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod()]
+        public void IsEmail_WhenEmailIsInvalid_ShouldReturnsFalse_1()
+        {
+            // Arrange
+            var registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+            string email = "admin@enkay";
+
+            // Act
+            var result = RegisterViewModel.IsEmail(email);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod()]
+        public void IsEmail_WhenEmailIsInvalid_ShouldReturnsFalse_2()
+        {
+            // Arrange
+            var registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+            string email = "admin@enkay.";
+
+            // Act
+            var result = RegisterViewModel.IsEmail(email);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod()]
+        public void IsEmail_WhenEmailIsInvalid_ShouldReturnsFalse_3()
+        {
+            // Arrange
+            var registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+            string email = "admin@.live";
+
+            // Act
+            var result = RegisterViewModel.IsEmail(email);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod()]
+        public void IsEmail_WhenEmailIsInvalid_ShouldReturnsFalse_4()
+        {
+            // Arrange
+            var registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+            string email = "admin@";
+
+            // Act
+            var result = RegisterViewModel.IsEmail(email);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod()]
+        public void IsEmail_WhenEmailIsInvalid_ShouldReturnsFalse_5()
+        {
+            // Arrange
+            var registerViewModel = new RegisterViewModel(_employeeRepositoryMock.Object);
+            string email = "admin";
+
+            // Act
+            var result = RegisterViewModel.IsEmail(email);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod()]
+        public async Task SaveEmployee_WhenAllParametersAreValid_ShouldCallSaveEmployee()
+        {
+            // Arrange
+            string name = "Admin";
+            string email = "admin@enkay.live";
+            string password = "12345678Aa";
+            string confirmPassword = "12345678Aa";
+
+            // Act
+            await _registerViewModel.SaveEmployee(name, email, password, confirmPassword);
+
+            // Assert
+            _employeeRepositoryMock.Verify(x => x.SaveEmployee(It.IsAny<Employee>()), Times.Once);
+        }
+
+        [TestMethod()]
+        public async Task SaveEmployee_WhenPasswordDoesNotMatchConfirmPassword_ShouldThrowArgumentException()
+        {
+            // Arrange
+            string name = "Admin";
+            string email = "admin@enkay.live";
+            string password = "12345678Aa";
+            string confirmPassword = "12345678A";
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _registerViewModel.SaveEmployee(name, email, password, confirmPassword));
+            Assert.AreEqual("Passwords do not match", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task SaveEmployee_WhenPasswordIsNotStrong_ShouldThrowArgumentException()
+        {
+            // Arrange
+            string name = "Admin";
+            string email = "admin@enkay.live";
+            string password = "12345678";
+            string confirmPassword = "12345678";
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(() => _registerViewModel.SaveEmployee(name, email, password, confirmPassword));
+            Assert.AreEqual("Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one number", ex.Message);
+        }
+
+        [TestMethod()]
+        public async Task SaveEmployee_WhenEmailIsInvalid_ShouldThrowFormatException()
+        {
+            // Arrange
+            string name = "Admin";
+            string email = "admin@enkay";
+            string password = "12345678Aa";
+            string confirmPassword = "12345678Aa";
+
+            // Act & Assert
+            var ex = await Assert.ThrowsExceptionAsync<FormatException>(() => _registerViewModel.SaveEmployee(name, email, password, confirmPassword));
+            Assert.AreEqual("Invalid email address", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
### Description
- This pull request adds comprehensive unit tests for the **ViewModels** in the POSSystem project. 
- The following ViewModels have been covered in **6 classes**: RegisterViewModel, LoginViewModel, BrandViewModel, CategoryViewModel, ProductViewModel, AddProductViewModel.

### Changes
  - Added unit tests for RegisterViewModel to check password strength, email validation, and employee registration. 
  - Added unit tests for LoginViewModel to test login, Google authentication, and credential management. 
  - Added unit tests for BrandViewModel to ensure proper loading and addition of brands. 
  - Added unit tests for CategoryViewModel to verify category loading and addition functionality. 
  - Added unit tests for ProductViewModel to validate product loading, filtering, sorting, and payment processing. 
  - Added unit tests for AddProductViewModel to ensure categories and brands are loaded correctly and products are saved properly.

### How to check?
- Open Visual Studio's **Test Explorer** option
- Click the **run all tests** button to see the results
![image](https://github.com/user-attachments/assets/6a9f37ba-ba99-4bf1-850c-beea4399ea76)
