### PR TITLE
Deletion handling

### DIFF
--- a/POSSystem/Repositories/BrandRepository.cs
+++ b/POSSystem/Repositories/BrandRepository.cs
@@ -28,27 +28,38 @@ namespace POSSystem.Repositories
             string query = "SELECT * FROM Brand ORDER BY Id";
             await _connection.OpenAsync();
 
-            using (var cmd = new NpgsqlCommand(query, _connection))
-            using (var reader = await cmd.ExecuteReaderAsync())
+            try
             {
-                while (await reader.ReadAsync())
+                using (var cmd = new NpgsqlCommand(query, _connection))
+                using (var reader = await cmd.ExecuteReaderAsync())
                 {
-                    brands.Add(new Brand
+                    while (await reader.ReadAsync())
                     {
-                        Id = reader.GetInt32(0),
-                        Name = reader.GetString(1)
-                    });
+                        brands.Add(new Brand
+                        {
+                            Id = reader.GetInt32(0),
+                            Name = reader.GetString(1)
+                        });
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                // Log the exception
+                Console.WriteLine($"Error in GetAllBrands: {ex.Message}");
+                throw;
+            }
+            finally
+            {
+                await _connection.CloseAsync();
+            }
 
-            await _connection.CloseAsync();
             return brands;
         }
 
         public async Task<Brand> GetBrandById(int id)
         {
             var brands = await GetAllBrands();
-
             return brands.FirstOrDefault(m => m.Id == id);
         }
 
@@ -64,13 +75,24 @@ namespace POSSystem.Repositories
             string query = "INSERT INTO Brand (Name) VALUES (@Name)";
             await _connection.OpenAsync();
 
-            using (var cmd = new NpgsqlCommand(query, _connection))
+            try
             {
-                cmd.Parameters.AddWithValue("Name", brand.Name);
-                await cmd.ExecuteNonQueryAsync();
+                using (var cmd = new NpgsqlCommand(query, _connection))
+                {
+                    cmd.Parameters.AddWithValue("Name", brand.Name);
+                    await cmd.ExecuteNonQueryAsync();
+                }
             }
-
-            await _connection.CloseAsync();
+            catch (Exception ex)
+            {
+                // Log the exception
+                Console.WriteLine($"Error in AddBrand: {ex.Message}");
+                throw;
+            }
+            finally
+            {
+                await _connection.CloseAsync();
+            }
         }
 
         public async Task UpdateBrand(Brand brand)
@@ -78,14 +100,25 @@ namespace POSSystem.Repositories
             string query = "UPDATE Brand SET Name = @Name WHERE Id = @Id";
             await _connection.OpenAsync();
 
-            using (var cmd = new NpgsqlCommand(query, _connection))
+            try
             {
-                cmd.Parameters.AddWithValue("Id", brand.Id);
-                cmd.Parameters.AddWithValue("Name", brand.Name);
-                await cmd.ExecuteNonQueryAsync();
+                using (var cmd = new NpgsqlCommand(query, _connection))
+                {
+                    cmd.Parameters.AddWithValue("Id", brand.Id);
+                    cmd.Parameters.AddWithValue("Name", brand.Name);
+                    await cmd.ExecuteNonQueryAsync();
+                }
             }
-
-            await _connection.CloseAsync();
+            catch (Exception ex)
+            {
+                // Log the exception
+                Console.WriteLine($"Error in UpdateBrand: {ex.Message}");
+                throw;
+            }
+            finally
+            {
+                await _connection.CloseAsync();
+            }
         }
 
         public async Task DeleteBrand(int id)
@@ -93,13 +126,24 @@ namespace POSSystem.Repositories
             string query = "DELETE FROM Brand WHERE Id = @Id";
             await _connection.OpenAsync();
 
-            using (var cmd = new NpgsqlCommand(query, _connection))
+            try
             {
-                cmd.Parameters.AddWithValue("Id", id);
-                await cmd.ExecuteNonQueryAsync();
+                using (var cmd = new NpgsqlCommand(query, _connection))
+                {
+                    cmd.Parameters.AddWithValue("Id", id);
+                    await cmd.ExecuteNonQueryAsync();
+                }
             }
-
-            await _connection.CloseAsync();
+            catch (Exception ex)
+            {
+                // Log the exception
+                Console.WriteLine($"Error in DeleteBrand: {ex.Message}");
+                throw;
+            }
+            finally
+            {
+                await _connection.CloseAsync();
+            }
         }
     }
 }

--- a/POSSystem/Repositories/BrandRepository.cs
+++ b/POSSystem/Repositories/BrandRepository.cs
@@ -145,5 +145,30 @@ namespace POSSystem.Repositories
                 await _connection.CloseAsync();
             }
         }
+
+        public async Task<bool> HasReferencingProducts(int brandId)
+        {
+            string query = "SELECT COUNT(*) FROM Product WHERE BrandId = @BrandId";
+            await _connection.OpenAsync();
+
+            try
+            {
+                using (var cmd = new NpgsqlCommand(query, _connection))
+                {
+                    cmd.Parameters.AddWithValue("BrandId", brandId);
+                    var count = (long)await cmd.ExecuteScalarAsync();
+                    return count > 0;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error in HasReferencingProducts: {ex.Message}");
+                throw;
+            }
+            finally
+            {
+                await _connection.CloseAsync();
+            }
+        }
     }
 }

--- a/POSSystem/Repositories/EmployeeRepository.cs
+++ b/POSSystem/Repositories/EmployeeRepository.cs
@@ -202,7 +202,6 @@ namespace POSSystem.Repositories
             }
         }
 
-
         public async Task DeleteEmployee(int id)
         {
             try
@@ -214,6 +213,31 @@ namespace POSSystem.Repositories
                 {
                     cmd.Parameters.AddWithValue("Id", id);
                     await cmd.ExecuteNonQueryAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+            finally
+            {
+                await _connection.CloseAsync();
+            }
+        }
+
+        public async Task<bool> HasReferencingInvoices(int employeeId)
+        {
+            try
+            {
+                await _connection.OpenAsync();
+                string query = "SELECT COUNT(*) FROM Invoice WHERE EmployeeId = @EmployeeId";
+
+                using (var cmd = new NpgsqlCommand(query, _connection))
+                {
+                    cmd.Parameters.AddWithValue("EmployeeId", employeeId);
+                    var count = (long)await cmd.ExecuteScalarAsync();
+                    return count > 0;
                 }
             }
             catch (Exception ex)

--- a/POSSystem/Repositories/IBrandRepository.cs
+++ b/POSSystem/Repositories/IBrandRepository.cs
@@ -11,5 +11,7 @@ namespace POSSystem.Repositories
         Task AddBrand(Brand brand);
         Task UpdateBrand(Brand brand);
         Task DeleteBrand(int id);
+
+        Task<bool> HasReferencingProducts(int brandId);
     }
 }

--- a/POSSystem/Repositories/ICategoryRepository.cs
+++ b/POSSystem/Repositories/ICategoryRepository.cs
@@ -11,5 +11,6 @@ namespace POSSystem.Repositories
         Task AddCategory(Category category);
         Task UpdateCategory(Category category);
         Task DeleteCategory(int id);
+        Task<bool> HasReferencingProducts(int categoryId); // New method
     }
 }

--- a/POSSystem/Repositories/IEmployeeRepository.cs
+++ b/POSSystem/Repositories/IEmployeeRepository.cs
@@ -9,13 +9,11 @@ namespace POSSystem.Repositories
         Task SaveEmployee(Employee employee);
 
         Task<Employee> GetEmployeeByEmail(string email);
-
         Task SaveEmployeeFromGoogle(Employee employee);
-
         Task<List<Employee>> GetAllEmployees();
-
         Task DeleteEmployee(int id);
 
         Task UpdateEmployee(Employee employee);
+        Task<bool> HasReferencingInvoices(int employeeId); // New method
     }
 }

--- a/POSSystem/Repositories/IProductRepository.cs
+++ b/POSSystem/Repositories/IProductRepository.cs
@@ -11,5 +11,6 @@ namespace POSSystem.Repositories
         Task AddProduct(Product product);
         Task UpdateProduct(Product product);
         Task DeleteProduct(int id);
+        Task<bool> HasReferencingInvoices(int productId); // New method
     }
 }

--- a/POSSystem/Repositories/ProductRepository.cs
+++ b/POSSystem/Repositories/ProductRepository.cs
@@ -26,33 +26,44 @@ namespace POSSystem.Repositories
         {
             var products = new List<Product>();
             string query = "SELECT * FROM Product ORDER BY Id";
-            await _connection.OpenAsync();
 
-            using (var cmd = new NpgsqlCommand(query, _connection))
-            using (var reader = await cmd.ExecuteReaderAsync())
+            try
             {
-                while (await reader.ReadAsync())
+                await _connection.OpenAsync();
+
+                using (var cmd = new NpgsqlCommand(query, _connection))
+                using (var reader = await cmd.ExecuteReaderAsync())
                 {
-                    products.Add(new Product
+                    while (await reader.ReadAsync())
                     {
-                        Id = reader.GetInt32(0),
-                        Name = reader.GetString(1),
-                        Price = reader.GetDecimal(2),
-                        Stock = reader.GetInt32(3),
-                        CategoryId = reader.GetInt32(4),
-                        BrandId = reader.GetInt32(5)
-                    });
+                        products.Add(new Product
+                        {
+                            Id = reader.GetInt32(0),
+                            Name = reader.GetString(1),
+                            Price = reader.GetDecimal(2),
+                            Stock = reader.GetInt32(3),
+                            CategoryId = reader.GetInt32(4),
+                            BrandId = reader.GetInt32(5)
+                        });
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+            finally
+            {
+                await _connection.CloseAsync();
+            }
 
-            await _connection.CloseAsync();
             return products;
         }
 
         public async Task<Product> GetProductById(int id)
         {
             var products = await GetAllProducts();
-
             return products.FirstOrDefault(p => p.Id == id);
         }
 
@@ -65,19 +76,30 @@ namespace POSSystem.Repositories
             }
 
             string query = "INSERT INTO Product (Name, Price, Stock, CategoryId, BrandId) VALUES (@Name, @Price, @Stock, @CategoryId, @BrandId)";
-            await _connection.OpenAsync();
 
-            using (var cmd = new NpgsqlCommand(query, _connection))
+            try
             {
-                cmd.Parameters.AddWithValue("Name", product.Name);
-                cmd.Parameters.AddWithValue("Price", product.Price);
-                cmd.Parameters.AddWithValue("Stock", NpgsqlTypes.NpgsqlDbType.Integer, product.Stock);
-                cmd.Parameters.AddWithValue("CategoryId", product.CategoryId);
-                cmd.Parameters.AddWithValue("BrandId", product.BrandId);
-                await cmd.ExecuteNonQueryAsync();
-            }
+                await _connection.OpenAsync();
 
-            await _connection.CloseAsync();
+                using (var cmd = new NpgsqlCommand(query, _connection))
+                {
+                    cmd.Parameters.AddWithValue("Name", product.Name);
+                    cmd.Parameters.AddWithValue("Price", product.Price);
+                    cmd.Parameters.AddWithValue("Stock", NpgsqlTypes.NpgsqlDbType.Integer, product.Stock);
+                    cmd.Parameters.AddWithValue("CategoryId", product.CategoryId);
+                    cmd.Parameters.AddWithValue("BrandId", product.BrandId);
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+            finally
+            {
+                await _connection.CloseAsync();
+            }
         }
 
         public async Task UpdateProduct(Product product)
@@ -89,34 +111,82 @@ namespace POSSystem.Repositories
             }
 
             string query = "UPDATE Product SET Name = @Name, Price = @Price, Stock = @Stock, CategoryId = @CategoryId, BrandId = @BrandId WHERE Id = @Id";
-            await _connection.OpenAsync();
 
-            using (var cmd = new NpgsqlCommand(query, _connection))
+            try
             {
-                cmd.Parameters.AddWithValue("Id", product.Id);
-                cmd.Parameters.AddWithValue("Name", product.Name);
-                cmd.Parameters.AddWithValue("Price", product.Price);
-                cmd.Parameters.AddWithValue("Stock", product.Stock);
-                cmd.Parameters.AddWithValue("CategoryId", product.CategoryId);
-                cmd.Parameters.AddWithValue("BrandId", product.BrandId);
-                await cmd.ExecuteNonQueryAsync();
-            }
+                await _connection.OpenAsync();
 
-            await _connection.CloseAsync();
+                using (var cmd = new NpgsqlCommand(query, _connection))
+                {
+                    cmd.Parameters.AddWithValue("Id", product.Id);
+                    cmd.Parameters.AddWithValue("Name", product.Name);
+                    cmd.Parameters.AddWithValue("Price", product.Price);
+                    cmd.Parameters.AddWithValue("Stock", product.Stock);
+                    cmd.Parameters.AddWithValue("CategoryId", product.CategoryId);
+                    cmd.Parameters.AddWithValue("BrandId", product.BrandId);
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+            finally
+            {
+                await _connection.CloseAsync();
+            }
         }
 
         public async Task DeleteProduct(int id)
         {
             string query = "DELETE FROM Product WHERE Id = @Id";
-            await _connection.OpenAsync();
 
-            using (var cmd = new NpgsqlCommand(query, _connection))
+            try
             {
-                cmd.Parameters.AddWithValue("Id", id);
-                await cmd.ExecuteNonQueryAsync();
-            }
+                await _connection.OpenAsync();
 
-            await _connection.CloseAsync();
+                using (var cmd = new NpgsqlCommand(query, _connection))
+                {
+                    cmd.Parameters.AddWithValue("Id", id);
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+            finally
+            {
+                await _connection.CloseAsync();
+            }
+        }
+
+        public async Task<bool> HasReferencingInvoices(int productId)
+        {
+            string query = "SELECT COUNT(*) FROM InvoiceItem WHERE ProductId = @ProductId";
+
+            try
+            {
+                await _connection.OpenAsync();
+
+                using (var cmd = new NpgsqlCommand(query, _connection))
+                {
+                    cmd.Parameters.AddWithValue("ProductId", productId);
+                    var count = (long)await cmd.ExecuteScalarAsync();
+                    return count > 0;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+            finally
+            {
+                await _connection.CloseAsync();
+            }
         }
     }
 }

--- a/POSSystem/ViewModels/BrandViewModel.cs
+++ b/POSSystem/ViewModels/BrandViewModel.cs
@@ -95,7 +95,7 @@ namespace POSSystem.ViewModels
         {
             if (await _brandRepository.HasReferencingProducts(brandId))
             {
-                await DialogHelper.DisplayErrorDialog("Cannot delete the brand because there are some product(s) with this brand.\nPLEASE DELETE THE PRODUCT(S) FIRST!");
+                await DialogHelper.DisplayErrorDialog("Cannot delete the brand because there are some product(s) with this brand.\nPLEASE DELETE THE PRODUCT(S) OR UPDATE THE PRODUCT'S BRAND!");
                 return;
             }
 

--- a/POSSystem/ViewModels/BrandViewModel.cs
+++ b/POSSystem/ViewModels/BrandViewModel.cs
@@ -1,4 +1,6 @@
-﻿using POSSystem.Models;
+﻿using Microsoft.UI.Xaml.Controls;
+using POSSystem.Helpers;
+using POSSystem.Models;
 using POSSystem.Repositories;
 using POSSystem.Services;
 using System;
@@ -91,8 +93,13 @@ namespace POSSystem.ViewModels
 
         public async Task DeleteBrand(int brandId)
         {
-            await _brandRepository.DeleteBrand(brandId);
+            if (await _brandRepository.HasReferencingProducts(brandId))
+            {
+                await DialogHelper.DisplayErrorDialog("Cannot delete the brand because there are some product(s) with this brand.\nPLEASE DELETE THE PRODUCT(S) FIRST!");
+                return;
+            }
 
+            await _brandRepository.DeleteBrand(brandId);
             await LoadBrands();
         }
     }

--- a/POSSystem/ViewModels/CategoryViewModel.cs
+++ b/POSSystem/ViewModels/CategoryViewModel.cs
@@ -1,4 +1,5 @@
-﻿using POSSystem.Models;
+﻿using POSSystem.Helpers;
+using POSSystem.Models;
 using POSSystem.Repositories;
 using POSSystem.Services;
 using System;
@@ -91,8 +92,13 @@ namespace POSSystem.ViewModels
 
         public async Task DeleteCategory(int categoryId)
         {
-            await _categoryRepository.DeleteCategory(categoryId);
+            if (await _categoryRepository.HasReferencingProducts(categoryId))
+            {
+                await DialogHelper.DisplayErrorDialog("Cannot delete the category because there are some product(s) with this category.\nPLEASE DELETE THE PRODUCT(S) FIRST!");
+                return;
+            }
 
+            await _categoryRepository.DeleteCategory(categoryId);
             await LoadCategories();
         }
     }

--- a/POSSystem/ViewModels/CategoryViewModel.cs
+++ b/POSSystem/ViewModels/CategoryViewModel.cs
@@ -94,7 +94,7 @@ namespace POSSystem.ViewModels
         {
             if (await _categoryRepository.HasReferencingProducts(categoryId))
             {
-                await DialogHelper.DisplayErrorDialog("Cannot delete the category because there are some product(s) with this category.\nPLEASE DELETE THE PRODUCT(S) FIRST!");
+                await DialogHelper.DisplayErrorDialog("Cannot delete the category because there are some product(s) with this category.\nPLEASE DELETE THE PRODUCT(S) OR UPDATE THE PRODUCT'S CATEGORY!");
                 return;
             }
 

--- a/POSSystem/ViewModels/EmployeeViewModel.cs
+++ b/POSSystem/ViewModels/EmployeeViewModel.cs
@@ -1,4 +1,5 @@
-﻿using POSSystem.Models;
+﻿using POSSystem.Helpers;
+using POSSystem.Models;
 using POSSystem.Repositories;
 using POSSystem.Services;
 using System;
@@ -9,7 +10,7 @@ using System.Threading.Tasks;
 namespace POSSystem.ViewModels
 {
     //TODO: need to use FullyObservableCollection instead of keep querying the database
-    public class EmployeeViewModel:BaseViewModel
+    public class EmployeeViewModel : BaseViewModel
     {
         private readonly IEmployeeRepository _employeeRepository;
 
@@ -67,11 +68,17 @@ namespace POSSystem.ViewModels
                 throw;
             }
         }
-
+        
         public async Task DeleteEmployee(int employeeID)
         {
             try
             {
+                if (await _employeeRepository.HasReferencingInvoices(employeeID))
+                {
+                    await DialogHelper.DisplayErrorDialog("Cannot delete the employee because there are some invoice(s) with this employee.\nPLEASE DELETE THE INVOICE(S) FIRST!");
+                    return;
+                }
+
                 await _employeeRepository.DeleteEmployee(employeeID);
                 await LoadEmployees();
             }
@@ -118,7 +125,5 @@ namespace POSSystem.ViewModels
                 throw;
             }
         }
-
-
     }
 }

--- a/POSSystem/ViewModels/EmployeeViewModel.cs
+++ b/POSSystem/ViewModels/EmployeeViewModel.cs
@@ -75,7 +75,7 @@ namespace POSSystem.ViewModels
             {
                 if (await _employeeRepository.HasReferencingInvoices(employeeID))
                 {
-                    await DialogHelper.DisplayErrorDialog("Cannot delete the employee because there are some invoice(s) with this employee.\nPLEASE DELETE THE INVOICE(S) FIRST!");
+                    await DialogHelper.DisplayErrorDialog("Cannot delete the employee because there are some invoice(s) created by this employee.\nPLEASE DELETE THE INVOICE(S) OR UPDATE IT NOT TO BE REGISTERED WITH THE EMPLOYEE!");
                     return;
                 }
 

--- a/POSSystem/ViewModels/ProductViewModel.cs
+++ b/POSSystem/ViewModels/ProductViewModel.cs
@@ -1,4 +1,5 @@
-﻿using POSSystem.Models;
+﻿using POSSystem.Helpers;
+using POSSystem.Models;
 using POSSystem.Repositories;
 using POSSystem.Services;
 using System;
@@ -176,9 +177,22 @@ namespace POSSystem.ViewModels
 
         public async Task DeleteProduct(int id)
         {
-            await _productRepository.DeleteProduct(id);
+            try
+            {
+                if (await _productRepository.HasReferencingInvoices(id))
+                {
+                    await DialogHelper.DisplayErrorDialog("Cannot delete the product because there are some invoice(s) with this product.\nPLEASE DELETE THE INVOICE(S) FIRST!");
+                    return;
+                }
 
-            await LoadProducts();
+                await _productRepository.DeleteProduct(id);
+                await LoadProducts();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                throw;
+            }
         }
 
         public async Task FilterProducts()

--- a/POSSystem/ViewModels/ProductViewModel.cs
+++ b/POSSystem/ViewModels/ProductViewModel.cs
@@ -181,7 +181,7 @@ namespace POSSystem.ViewModels
             {
                 if (await _productRepository.HasReferencingInvoices(id))
                 {
-                    await DialogHelper.DisplayErrorDialog("Cannot delete the product because there are some invoice(s) with this product.\nPLEASE DELETE THE INVOICE(S) FIRST!");
+                    await DialogHelper.DisplayErrorDialog("Cannot delete the product because there are some invoice(s) with this product.\nPLEASE DELETE THE INVOICE(S) OR UPDATE IT TO NOT HOLDING INFORMATION ABOUT THE PRODUCT!");
                     return;
                 }
 

--- a/POSSystem/Views/EmployeesPage.xaml.cs
+++ b/POSSystem/Views/EmployeesPage.xaml.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using Microsoft.UI.Xaml;
 using System.Threading.Tasks;
+using POSSystem.Helpers;
 
 namespace POSSystem.Views
 {
@@ -48,7 +49,7 @@ namespace POSSystem.Views
                 }
                 catch (Exception ex)
                 {
-                    await DisplayErrorDialog(ex.Message);
+                    await DialogHelper.DisplayErrorDialog(ex.Message);
                 }
             }
 
@@ -100,11 +101,11 @@ namespace POSSystem.Views
                     }
                     catch (ArgumentException ex)
                     {
-                        await DisplayErrorDialog(ex.Message);
+                        await DialogHelper.DisplayErrorDialog(ex.Message);
                     }
                     catch (Exception ex)
                     {
-                        await DisplayErrorDialog("An unexpected error occurred: " + ex.Message);
+                        await DialogHelper.DisplayErrorDialog("An unexpected error occurred: " + ex.Message);
                         break; // Exit the loop on unexpected errors
                     }
                 }
@@ -117,17 +118,6 @@ namespace POSSystem.Views
 
         // Detail: Title = "ERROR", CloseButtonText = "Ok", XamlRoot = this.XamlRoot
         // Content = contentMessage (parameter passed in)
-        private async Task DisplayErrorDialog(string contentMessage)
-        {
-            ContentDialog errorDialog = new()
-            {
-                Title = "ERROR",
-                Content = contentMessage,
-                CloseButtonText = "Ok",
-                XamlRoot = this.XamlRoot
-            };
-
-            await errorDialog.ShowAsync();
-        }
+        
     }
 }


### PR DESCRIPTION
- When user try to delete an object being referenced by another, display error message first (not performing the illegal action on db). Ask the user to delete the referencing-object first (specifying it as 'product(s), brand(s)..'
- Refactor: use try-catch-finally to ensure proper connection closing in the repository files

- How to test:
- Just pull the code, start the app and try deleting some brand, category (bounded by product); delete some employees (bounded by invoice); and deleting some products (bound by invoice)
- **This means ultimately the user have to ensure no invoices saving the want-to-delete product/ employee first**; this aligns well with the organization of our app's data
_P/s: Maybe some extension in the future can have that we perform the cascading deletion (on behalf of the user) if the user wishes so? This seems like a double-edged knife, especially if we don't provide back-up features_